### PR TITLE
chore: add `ListObjects` RFC PR reference to the metadata

### DIFF
--- a/20220714-listObjects-api.md
+++ b/20220714-listObjects-api.md
@@ -4,7 +4,7 @@
 - **Start Date**: 2022-07-14
 - **Author(s)**: jon-whit
 - **Status**: Approved <!-- Acceptable values: Draft, Approved, On Hold, Superseded -->
-- **RFC Pull Request**: (leave blank)
+- **RFC Pull Request**: #3
 - **Relevant Issues**:
   - https://github.com/openfga/openfga/issues/101
   - https://github.com/openfga/api/issues/10

--- a/20220714-listObjects-api.md
+++ b/20220714-listObjects-api.md
@@ -4,7 +4,7 @@
 - **Start Date**: 2022-07-14
 - **Author(s)**: jon-whit
 - **Status**: Approved <!-- Acceptable values: Draft, Approved, On Hold, Superseded -->
-- **RFC Pull Request**: #3
+- **RFC Pull Request**: https://github.com/openfga/rfcs/pull/3
 - **Relevant Issues**:
   - https://github.com/openfga/openfga/issues/101
   - https://github.com/openfga/api/issues/10


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Add missing meta for the PR number for ListObjects.

## References
#3 

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
