### PR TITLE
chore: update RFC process

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ Once an RFC has been accepted, the sub-team maintainers should:
 
 Once an `issues-created/<sub-team>` label has been created for each sub-team, the RFC is ready to merge. The team member who merges the pull request should do the following:
 
-1. Assign an id based off the pull request number.
-1. Rename the file based off the ID inside `text/`.
 1. Fill in the remaining metadata at the top.
 1. Commit everything.
 1. Update issues with RFC ID and a link to the text file.


### PR DESCRIPTION
## Description

Instead of adding a new label, we will use the original RFC date.

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [ ] The correct base branch is being used, if not `main`
