### PR TITLE
Fix: Readme labels, Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,6 @@ To get a proposal into OpenFGA, an RFC first needs to be merged into the RFC rep
 ### Development
 Once a pull request is opened, the RFC is now in development and the following will happen:
 
-1. The following labels will be applied as appropriate:
- * `label1/<sublabel>`
- * `label2/<sublabel>`
 1. The core team will discuss as much as possible in the RFC pull request directly. Any outside discussion will be summarized in the comment thread.
 1. When deemed "ready", a core team member will propose a "motion for final comment period (FCP)" along with a disposition of the outcome (merge, close, or postpone). This is a step taken when enough discussion of the tradeoffs have taken place and the team is in a position to make a decision. Before entering FCP, super majority of the core team must sign off.
 
@@ -69,6 +66,10 @@ When a pull request enters FCP the following will happen:
     
     Non-binding votes are of course welcome. Super majority means 2/3 or greater and no single company can have more than 50% of countable votes.
 1. If no substantial new arguments or ideas are raised, the FCP will follow the outcome decided. If there are substantial new arguments, then the RFC will go back into development.
+1. The following labels will be applied as appropriate:
+ * `resolution/merge`: the proposal will be merged; there are no outstanding objections, and implementation can begin as soon as the RFC is merged.
+ * `resolution/close`: the proposal will be closed.
+ * `resolution/postpone`: resolution will be deferred until a later time when the motivating or blocking factors may have changed.
 
 ### Merge
 Once an RFC has been accepted, the sub-team maintainers should:

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ Want to suggest a change to the OpenFGA project? That's great! We follow an RFC 
 
 Check out the PRs below to see and contribute to features the core team and community are currently evaluating. Let us know your feedback with emojis and comments.
 
-| Feature                                                                                                                                                             |  PR                                           | Status            |
-|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------:|:------------------|
-|[Add RFC for ExpandedWatch API](https://github.com/openfga/rfcs/blob/4fde509fb46c3ed383d8681e4db7292eeb94fe32/20220729-expandedWatch-api.md)                         |  [#4](https://github.com/openfga/rfcs/pull/4) | Draft             |
-|[Add type restrictions to DSL Syntax](https://github.com/openfga/rfcs/blob/9358259af56895e483a8e613e446f4bedd9abe1e/20221012-add-type-restrictions-to-dsl-syntax.md) |  [#7](https://github.com/openfga/rfcs/pull/7) | Open for Comments |
-|[Add type restrictions to JSON](https://github.com/openfga/rfcs/blob/50948e8330dcc4689f1c8785a460695d2c3b6fab/20220831-add-type-restrictions-to-json-syntax.md)      |  [#8](https://github.com/openfga/rfcs/pull/8) | Draft             |
+| Feature                                                                                                                                                             | PR                                             | Status            |
+|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------:|:------------------|
+|[ExpandedWatch API](https://github.com/openfga/rfcs/blob/4fde509fb46c3ed383d8681e4db7292eeb94fe32/20220729-expandedWatch-api.md)                                     | [#4](https://github.com/openfga/rfcs/pull/4)   | Draft             |
+|[Add type restrictions to DSL Syntax](https://github.com/openfga/rfcs/blob/9358259af56895e483a8e613e446f4bedd9abe1e/20221012-add-type-restrictions-to-dsl-syntax.md) | [#7](https://github.com/openfga/rfcs/pull/7)   | Open for Comments |
+|[Add type restrictions to JSON](https://github.com/openfga/rfcs/blob/50948e8330dcc4689f1c8785a460695d2c3b6fab/20220831-add-type-restrictions-to-json-syntax.md)      | [#8](https://github.com/openfga/rfcs/pull/8)   | Draft             |
+|[Endpoint Authorizations](https://github.com/openfga/rfcs/blob/fe5eaeffc2230d162297296d4d3388fe4d065d44/20221103-endpoint-authz.md)                                  | [#10](https://github.com/openfga/rfcs/pull/10) | Open for Comments |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An RFC is not necessary for changes which have narrow scope and don't leave much
 
 The RFC process aims to prevent wasted time and effort on substantial changes that end up being sent back to the drawing board. If your change takes minimal effort, or if you don't mind potentially scrapping it and starting over, feel free to skip this process. Do note however that pull requests may be closed with a polite request to submit an RFC.
 
-If you're not sure whether to open an RFC for a change you'd like to propose, feel free to ask in our Discord's [#dev channel](#discord-link)!
+If you're not sure whether to open an RFC for a change you'd like to propose, feel free to ask in our [Discord's #fga-feedback channel](https://discord.com/invite/8naAwJfWN6)!
 
 ---
 


### PR DESCRIPTION
Readme corrections: labels section makes more sense after an RFC review is finished, discord link is now functional.

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
